### PR TITLE
feat(script.sh): add shebang

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 mkdir ~/creation_script/assets
 git clone https://github.com/rollingrhinoremix/distro ~/creation_script/assets
 apt update -y


### PR DESCRIPTION
This is needed to specify what is being used for example without shebang, some tools [shellcheck](shellcheck.net) wouldn't work. Plus it is sometimes used by text editors to detect if it is a shell script too @MrBeeBenson so a bit of functionallity I guess.